### PR TITLE
Add support for temporary set point override based on schedule.

### DIFF
--- a/addons/binding/org.openhab.binding.evohome/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.evohome/ESH-INF/thing/bridge.xml
@@ -9,6 +9,10 @@
 				<label>Authentication</label>
 				<description>Contains the settings needed to authenticate against the TCC service.</description>
 			</parameter-group>
+			<parameter-group name="heating">
+                <label>Heating</label>
+                <description>Heating Settings.</description>
+            </parameter-group>
 			<parameter name="username" type="text" required="true" groupName="auth">
 				<label>Username</label>
 				<description>Your TCC Username</description>
@@ -23,6 +27,11 @@
 				<description>The refresh interval to poll TCC (in seconds).</description>
 				<default>15</default>
 				<advanced>true</advanced>
+			</parameter>
+			<parameter name="temporaryOverrideSchedule" type="boolean" required="false" groupName="heating">
+                <label>Temporary Override Schedule</label>
+                <description>Setting a new temperature overrides the zone schedule temporary instead of permanent.</description>
+                <default>false</default>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/handler/EvohomeHeatingZoneHandler.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/handler/EvohomeHeatingZoneHandler.java
@@ -84,7 +84,7 @@ public class EvohomeHeatingZoneHandler extends BaseEvohomeHandler {
                         newTemp = 5;
                     }
                     if (newTemp >= 5 && newTemp <= 35) {
-                        bridge.setPermanentSetPoint(getEvohomeThingConfig().id, newTemp);
+                        bridge.setHeatSetPoint(getEvohomeThingConfig().id, newTemp);
                     }
                 }
             }

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/handler/ScheduleHelper.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/handler/ScheduleHelper.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.evohome.handler;
+
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.openhab.binding.evohome.internal.api.models.v2.response.DailySchedule;
+import org.openhab.binding.evohome.internal.api.models.v2.response.DailySchedules;
+import org.openhab.binding.evohome.internal.api.models.v2.response.SwitchPoint;
+
+/**
+ * Class to find current and future schedules.
+ *
+ * @author Jeroen Peters
+ *
+ */
+public class ScheduleHelper {
+
+    private DailySchedules schedules;
+
+    public ScheduleHelper(DailySchedules schedules) {
+        this.schedules = schedules;
+    }
+
+    public boolean hasSchedule() {
+        boolean result = false;
+
+        for (DailySchedule schedule : schedules) {
+            if (schedule.getSwitchPoints().size() > 0) {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    public ZonedDateTime getStartNextSwitchPoint(ZonedDateTime zoned) {
+        // Map zoned day index to schedule list (Monday = 0, Sunday = 6)
+        int todayIndex = zoned.getDayOfWeek().getValue() - 1;
+        LocalTime time = zoned.toLocalTime();
+
+        List<SwitchPoint> switchPoints = schedules.get(todayIndex).getSwitchPoints();
+        for (SwitchPoint switchPoint : switchPoints) {
+            if (time.compareTo(switchPoint.getTimeOfDay()) < 0) {
+                return zoned.with(switchPoint.getTimeOfDay());
+            }
+        }
+
+        // No start time found, look for switch point in upcoming days
+        for (int day = (todayIndex + 1) % 7; day != todayIndex; day = (day + 1) % 7) {
+            if (schedules.get(day).getSwitchPoints().size() > 0) {
+                LocalTime timeOfDay = schedules.get(day).getSwitchPoints().get(0).getTimeOfDay();
+                int days = day - todayIndex;
+                if (days < 0) {
+                    days = days + 7;
+                }
+                return zoned.plusDays(days).with(timeOfDay);
+            }
+        }
+
+        // If still not found, return the time of the first switch point of today next week
+        if (switchPoints.size() > 0) {
+            return zoned.plusDays(7).with(switchPoints.get(0).getTimeOfDay());
+        }
+
+        return null;
+    }
+
+    public double getScheduleTemperature(ZonedDateTime zoned) {
+
+        // Map zoned day index to schedule list (Monday = 0, Sunday = 6)
+        int todayIndex = zoned.getDayOfWeek().getValue() - 1;
+        LocalTime time = zoned.toLocalTime();
+
+        List<SwitchPoint> switchPoints = schedules.get(todayIndex).getSwitchPoints();
+        for (int i = switchPoints.size() - 1; i >= 0; i--) {
+            if (time.compareTo(switchPoints.get(i).getTimeOfDay()) > 0) {
+                return switchPoints.get(i).getheatSetpoint();
+            }
+        }
+
+        // No temperature found, look for switch point in previous days
+        for (int day = (todayIndex - 1) % 7; day != todayIndex; day = (day - 1) % 7) {
+            if (day < 0) {
+                day = day + 7;
+            }
+            if (schedules.get(day).getSwitchPoints().size() > 0) {
+                return schedules.get(day).getSwitchPoints().get(schedules.get(day).getSwitchPoints().size() - 1)
+                        .getheatSetpoint();
+            }
+
+        }
+
+        // If still not found, return the temperature of the last switch point of zoned day
+        if (switchPoints.size() > 0) {
+            return switchPoints.get(switchPoints.size() - 1).getheatSetpoint();
+        }
+
+        return 0.0;
+    }
+}

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/ApiAccess.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/ApiAccess.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.evohome.internal.api;
 
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
 
 /**
  * Provides access to (an optionally OAUTH based) API. Makes sure that all the necessary headers are set.
@@ -104,7 +106,11 @@ public class ApiAccess {
                 String reply = response.getContentAsString();
 
                 if (outClass != null) {
-                    retVal = new Gson().fromJson(reply, outClass);
+                    Gson gson = new GsonBuilder().registerTypeAdapter(LocalTime.class,
+                            (JsonDeserializer<LocalTime>) (json, type, jsonDeserializationContext) -> LocalTime
+                                    .parse(json.getAsJsonPrimitive().getAsString()))
+                            .create();
+                    retVal = gson.fromJson(reply, outClass);
                 }
             }
         } catch (InterruptedException | ExecutionException e) {

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/request/HeatSetPoint.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/request/HeatSetPoint.java
@@ -32,11 +32,16 @@ public class HeatSetPoint {
      *
      * @param setPoint The target temperature to set the set point to
      */
-    HeatSetPoint(double setPoint) {
+    HeatSetPoint(double setPoint, String until) {
         // Make sure that the value is rounded toward the nearest 0.5
         heatSetpointValue = Math.round(setPoint * 2) / 2.0;
-        setpointMode = "PermanentOverride";
-        timeUntil = null;
+        if (until == null) {
+            setpointMode = "PermanentOverride";
+            timeUntil = null;
+        } else {
+            setpointMode = "TemporaryOverride";
+            timeUntil = until;
+        }
     }
 
     @SerializedName("heatSetpointValue")

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/request/HeatSetPointBuilder.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/request/HeatSetPointBuilder.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.evohome.internal.api.models.v2.request;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * Builder for heat set point API requests
  *
@@ -19,6 +22,7 @@ public class HeatSetPointBuilder implements RequestBuilder<HeatSetPoint> {
     private double setPoint;
     private boolean hasSetPoint;
     private boolean cancelSetPoint;
+    private String until;
 
     /**
      * Creates a new heat set point command
@@ -32,7 +36,7 @@ public class HeatSetPointBuilder implements RequestBuilder<HeatSetPoint> {
             return new HeatSetPoint();
         }
         if (hasSetPoint) {
-            return new HeatSetPoint(setPoint);
+            return new HeatSetPoint(setPoint, until);
         }
         return null;
     }
@@ -45,6 +49,15 @@ public class HeatSetPointBuilder implements RequestBuilder<HeatSetPoint> {
 
     public HeatSetPointBuilder setCancelSetPoint() {
         cancelSetPoint = true;
+        return this;
+    }
+
+    public HeatSetPointBuilder setUntil(ZonedDateTime until) {
+        if (until == null) {
+            this.until = null;
+        } else {
+            this.until = until.format(DateTimeFormatter.ISO_INSTANT);
+        }
         return this;
     }
 

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/DailySchedule.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/DailySchedule.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.evohome.internal.api.models.v2.response;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response model for a daily schedule
+ * 
+ * @author Jeroen Peters
+ *
+ */
+public class DailySchedule {
+
+    @SerializedName("dayOfWeek")
+    private String dayOfWeek;
+
+    @SerializedName("switchpoints")
+    private List<SwitchPoint> switchPoints;
+
+    public String getDayofWeek() {
+        return dayOfWeek;
+    }
+
+    public List<SwitchPoint> getSwitchPoints() {
+        return switchPoints;
+    }
+}

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/DailySchedules.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/DailySchedules.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.evohome.internal.api.models.v2.response;
+
+import java.util.ArrayList;
+
+/**
+ * Alias for a list of daily schedules
+ *
+ * @author Jeroen Peters
+ *
+ */
+public class DailySchedules extends ArrayList<DailySchedule> {
+
+}

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/Schedule.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/Schedule.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.evohome.internal.api.models.v2.response;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response model for a zone schedule
+ *
+ * @author Jeroen Peters - Initial contribution
+ *
+ */
+public class Schedule {
+
+    @SerializedName("dailySchedules")
+    private DailySchedules dailySchedules;
+
+    public DailySchedules getDailySchedules() {
+        return dailySchedules;
+    }
+}

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/SwitchPoint.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/api/models/v2/response/SwitchPoint.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.evohome.internal.api.models.v2.response;
+
+import java.time.LocalTime;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response model for a schedule switch point
+ *
+ * @author Jeroen Peters
+ *
+ */
+public class SwitchPoint {
+
+    @SerializedName("heatSetpoint")
+    private double heatSetpoint;
+
+    @SerializedName("timeOfDay")
+    private LocalTime timeOfDay;
+
+    public double getheatSetpoint() {
+        return heatSetpoint;
+    }
+
+    public LocalTime getTimeOfDay() {
+        return timeOfDay;
+    }
+}

--- a/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/configuration/EvohomeAccountConfiguration.java
+++ b/addons/binding/org.openhab.binding.evohome/src/main/java/org/openhab/binding/evohome/internal/configuration/EvohomeAccountConfiguration.java
@@ -19,4 +19,5 @@ public class EvohomeAccountConfiguration {
     public String password;
     public String applicationId;
     public int refreshInterval;
+    public boolean temporaryOverrideSchedule;
 }


### PR DESCRIPTION
This PR adds support for temporary set point override based on schedule.

- Adds a preference to bridge configuration whether temperature should be temporary overridden or set permanent
- If temporary override is preferred, a new target temperature is set until the next scheduled switch point
- If temporary override is preferred and no schedule is found, temperature is set permanently
- If new target temperature matches the current scheduled temperature, the override is canceled (and heating follows schedule again)

If any more information is required, please let me know.
